### PR TITLE
Change Elite badge colour to bright green

### DIFF
--- a/src/leadtimeforchanges.ps1
+++ b/src/leadtimeforchanges.ps1
@@ -244,7 +244,7 @@ function Main ([string] $ownerRepo,
     elseif ($leadTimeForChangesInHours -le $dailyDeployment) 
     {
         $rating = "Elite"
-        $color = "green"
+        $color = "brightgreen"
         $displayMetric = [math]::Round($leadTimeForChangesInHours, 2)
         $displayUnit = "hours"
     }

--- a/src/leadtimeforchanges.ps1
+++ b/src/leadtimeforchanges.ps1
@@ -237,7 +237,7 @@ function Main ([string] $ownerRepo,
     elseif ($leadTimeForChangesInHours -lt 1) 
     {
         $rating = "Elite"
-        $color = "green"
+        $color = "brightgreen"
         $displayMetric = [math]::Round($leadTimeForChangesInHours * 60, 2)
         $displayUnit = "minutes"
     }


### PR DESCRIPTION
This will change badge colour for `Elite` category to bright green as against the lemon green previously used.