### PR TITLE
Update to new actions owner + typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A GitHub Action to roughly calculate DORA lead time for changes This is not mean
 
 To test the current repo (same as where the action runs)
 ```
-- uses: samsmithnz/lead-time-for-changes@main
+- uses: DeveloperMetrics/lead-time-for-changes@main
   with:
     workflows: 'CI'
 ```
@@ -38,7 +38,7 @@ To test the current repo (same as where the action runs)
 To test another repo, with all arguments
 ```
 - name: Test another repo
-  uses: samsmithnz/lead-time-for-changes@main
+  uses: DeveloperMetrics/lead-time-for-changes@main
   with:
     workflows: 'CI/CD'
     owner-repo: 'samsmithnz/DevOpsMetrics'
@@ -49,17 +49,17 @@ To test another repo, with all arguments
 To use a PAT token to access another (potentially private) repo:
 ```
 - name: Test elite repo with PAT Token
-  uses: samsmithnz/lead-time-for-changes@main
+  uses: DeveloperMetrics/lead-time-for-changes@main
   with:
     workflows: 'CI/CD'
     owner-repo: 'samsmithnz/SamsFeatureFlags'
     pat-token: "${{ secrets.PATTOKEN }}"
 ```
 
-Use the built in Actions GitHub Token to retrieve the metrix 
+Use the built in Actions GitHub Token to retrieve the metrics
 ```
 - name: Test this repo with GitHub Token
-  uses: samsmithnz/lead-time-for-changes@main
+  uses: DeveloperMetrics/lead-time-for-changes@main
   with:
     workflows: 'CI'
     actions-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -68,7 +68,7 @@ Use the built in Actions GitHub Token to retrieve the metrix
 Gather the metric from another repository using GitHub App authentication method:
 ```
 - name: Test another repo with GitHub App
-  uses: samsmithnz/lead-time-for-changes@main
+  uses: DeveloperMetrics/lead-time-for-changes@main
   with:
     workflows: 'CI'
     owner-repo: 'samsmithnz/some-other-repo'
@@ -103,6 +103,6 @@ In the job summary, we show a badge with details:
  **Definition:** For the primary application or service, how long does it take to go from code committed to code successfully running in production.<br>
  **Results:** Lead time for changes is **5.61 hours** with a **Elite** rating, over the last **30 days**.<br>
  **Details**:
- - Repository: samsmithnz/deployment-frequency using main branch
+ - Repository: DeveloperMetrics/deployment-frequency using main branch
  - Workflow(s) used: CI
  ---


### PR DESCRIPTION
The changes are related to updating the repository references and correcting a typo. The repository references have been changed from `samsmithnz/lead-time-for-changes` to `DeveloperMetrics/lead-time-for-changes`. Additionally, a typo in the word "metrics" has been corrected.

Main changes:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R41">`README.md`</a>: Updated the repository references in the usage instructions from `samsmithnz/lead-time-for-changes` to `DeveloperMetrics/lead-time-for-changes`.<a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R41">[1]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R62">[2]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71">[3]</a>
* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R62">`README.md`</a>: Corrected a typo from "metrix" to "metrics" in the instructions for using the built-in Actions GitHub Token.
* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R106">`README.md`</a>: Updated the repository reference in the job summary details from `samsmithnz/deployment-frequency` to `DeveloperMetrics/deployment-frequency`.