### PR TITLE
Update leadtimeforchanges.ps1

### DIFF
--- a/src/leadtimeforchanges.ps1
+++ b/src/leadtimeforchanges.ps1
@@ -44,7 +44,7 @@ function Main ([string] $ownerRepo,
 
     #==========================================
     # Get authorization headers
-    $authHeader = GetAuthHeader($patToken, $actionsToken)
+    $authHeader = GetAuthHeader $patToken $actionsToken $appId $appInstallationId $appPrivateKey
 
     #Get pull requests from the repo 
     #https://developer.GitHub.com/v3/pulls/#list-pull-requests


### PR DESCRIPTION
fixes #32.

This pull request includes a change to the `Main` function in the `src/leadtimeforchanges.ps1` file. The change modifies the `GetAuthHeader` function call to include three additional parameters: `appId`, `appInstallationId`, and `appPrivateKey`.

* [`src/leadtimeforchanges.ps1`](diffhunk://#diff-04fa94a628290382bfce7d74d66808ad2c71f58da3d2baf5c1ab25d144de46b7L47-R47): Modified the `GetAuthHeader` function call in the `Main` function to include `appId`, `appInstallationId`, and `appPrivateKey` parameters.

