### PR TITLE
Add markdown results as output and fix actionsToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ A GitHub Action to roughly calculate DORA lead time for changes This is not mean
 - `app-private-key` optional, string, defaults to '', private key which has been generated for the installed instance of the GitHub app. Must be provided without leading `'-----BEGIN RSA PRIVATE KEY----- '` and trailing `' -----END RSA PRIVATE KEY-----'`.
 
 To test the current repo (same as where the action runs)
-```
+```yml
 - uses: DeveloperMetrics/lead-time-for-changes@main
   with:
     workflows: 'CI'
 ```
 
 To test another repo, with all arguments
-```
+```yml
 - name: Test another repo
   uses: DeveloperMetrics/lead-time-for-changes@main
   with:
@@ -47,7 +47,7 @@ To test another repo, with all arguments
 ```
 
 To use a PAT token to access another (potentially private) repo:
-```
+```yml
 - name: Test elite repo with PAT Token
   uses: DeveloperMetrics/lead-time-for-changes@main
   with:
@@ -57,7 +57,7 @@ To use a PAT token to access another (potentially private) repo:
 ```
 
 Use the built in Actions GitHub Token to retrieve the metrics
-```
+```yml
 - name: Test this repo with GitHub Token
   uses: DeveloperMetrics/lead-time-for-changes@main
   with:
@@ -66,7 +66,7 @@ Use the built in Actions GitHub Token to retrieve the metrics
 ```
 
 Gather the metric from another repository using GitHub App authentication method:
-```
+```yml
 - name: Test another repo with GitHub App
   uses: DeveloperMetrics/lead-time-for-changes@main
   with:
@@ -75,6 +75,17 @@ Gather the metric from another repository using GitHub App authentication method
     app-id: "${{ secrets.APPID }}"
     app-install-id: "${{ secrets.APPINSTALLID }}"
     app-private-key: "${{ secrets.APPPRIVATEKEY }}"
+```
+
+Use the markdown file output for some other action downstream:
+```yml
+- name: Generate lead time for changes markdown file
+  uses: DeveloperMetrics/lead-time-for-changes@main
+  id: lead-time
+  with:
+    workflows: 'CI'
+    actions-token: "${{ secrets.GITHUB_TOKEN }}"
+- run: cat ${{ steps.lead-time.outputs.markdown-file }})
 ```
 
 # Setup

--- a/action.yml
+++ b/action.yml
@@ -39,11 +39,19 @@ inputs:
   app-private-key:
     description: 'private key which has been generated for the installed instance of the GitHub app'
     default: ""
+outputs:
+  markdown-file:
+    description: "The markdown that will be posted to the job summary, so that the markdown can saved and used other places (e.g.: README.md)"
+    value: ${{ steps.lead-time.outputs.markdown-file }}
 runs:
   using: "composite"
   steps:
     - name: Run DORA lead time for changes
+      id: lead-time
       shell: pwsh
       run: |
          $result = ${{ github.action_path }}/src/leadtimeforchanges.ps1 -ownerRepo "${{ inputs.owner-repo }}" -workflows "${{ inputs.workflows }}" -branch "${{ inputs.default-branch }}" -numberOfDays ${{ inputs.number-of-days }} -commitCountingMethod ${{ inputs.commit-counting-method }} -patToken "${{ inputs.pat-token }}" -actionsToken "${{ inputs.actions-token }}" -appId "${{ inputs.app-id }}" -appInstallationId "${{ inputs.app-install-id }}" -appPrivateKey "${{ inputs.app-private-key }}"             
+         $filePath="dora-lead-time-markdown.md"
+         Set-Content -Path $filePath -Value $result
+         "markdown-file=$filePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
          Write-Output $result >> $env:GITHUB_STEP_SUMMARY

--- a/src/leadtimeforchanges.ps1
+++ b/src/leadtimeforchanges.ps1
@@ -309,7 +309,7 @@ function GetAuthHeader ([string] $patToken, [string] $actionsToken, [string] $ap
     elseif (![string]::IsNullOrEmpty($actionsToken))
     {
         Write-Host "Authentication detected: GITHUB TOKEN"  
-        $authHeader = @{Authorization=("Bearer {0}" -f $base64AuthInfo)}
+        $authHeader = @{Authorization=("Bearer {0}" -f $actionsToken)}
     }
     elseif (![string]::IsNullOrEmpty($appId)) # GitHup App auth
     {


### PR DESCRIPTION
1. Write the markdown results to a file and create that file as an output (so that teams can use this markdown elsewhere, ie [creating a process to publish this to the README.md](https://github.com/joshjohanning-org/dora-metrics-actions-test/blob/29f5974cbf45f722654f22fb7a9fa79483ca38ed/.github/workflows/dora-metrics-actions.yml#L30-L64).
2. Fix `actionsToken` since it wasn't working - I think it was copy/paste error referring to wrong variable
    - It seems like one could simply remove this input and combine it with the PatToken parameter - but perhaps PowerShell is more finicky than I think between PATs and the GitHub Token.
    - For what it's worth, the `GITHUB_TOKEN` now works with both the `actions-token` and `pat-token` input ([see workflow](https://github.com/joshjohanning-org/dora-metrics-actions-test/blob/4dc2348a4d0f861824f6b3d4a1f26604f130c687/.github/workflows/dora-metrics-actions.yml#L30-L43))

same PR made in other action:
- https://github.com/DeveloperMetrics/deployment-frequency/pull/57