### PR TITLE
feat: support GitHub Enterprise Server environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ A GitHub Action to roughly calculate DORA lead time for changes This is not mean
 - `owner-repo`: optional, string, defaults to the repo where the action runs. Can target another owner or org and repo. e.g. `'DeveloperMetrics/DevOpsMetrics'`, but will require authenication (see below)
 - `default-branch`: optional, string, defaults to `main` 
 - `number-of-days`: optional, integer, defaults to `30` (days)
-- commit-counting-method: #optional, defaults to 'last'. Accepts two values, 'last' - to start timing from the last commit of a PR, and 'first' to start timing from the first commit of a PR
+- `commit-counting-method`: #optional, defaults to 'last'. Accepts two values, 'last' - to start timing from the last commit of a PR, and 'first' to start timing from the first commit of a PR
 - `pat-token`: optional, string, defaults to ''. Can be set with GitHub PAT token. Ensure that `Read access to actions and metadata` permission is set. This is a secret, never directly add this into the actions workflow, use a secret.
 - `actions-token`: optional, string, defaults to ''. Can be set with `${{ secrets.GITHUB_TOKEN }}` in the action
 - `app-id`: optional, string, defaults to '', application id of the registered GitHub app
 - `app-install-id`: optional, string, defaults to '', id of the installed instance of the GitHub app
-- `app-private-key` optional, string, defaults to '', private key which has been generated for the installed instance of the GitHub app. Must be provided without leading `'-----BEGIN RSA PRIVATE KEY----- '` and trailing `' -----END RSA PRIVATE KEY-----'`.
+- `app-private-key`: optional, string, defaults to '', private key which has been generated for the installed instance of the GitHub app. Must be provided without leading `'-----BEGIN RSA PRIVATE KEY----- '` and trailing `' -----END RSA PRIVATE KEY-----'`.
+- `api-url`: optional, string, defaults to `${{ github.api_url }}` which should cover both github.com and GitHub Enterprise Server.
 
 To test the current repo (same as where the action runs)
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'DORA lead time for changes'
 description: 'A GitHub Action to roughly calculate DORA lead time for changes'
-author: developermetrics.org 
+author: developermetrics.org
 branding:
   icon: activity
   color: gray-dark
@@ -39,6 +39,9 @@ inputs:
   app-private-key:
     description: 'private key which has been generated for the installed instance of the GitHub app'
     default: ""
+  api-url:
+    description: 'the URL of the GitHub API'
+    default: ${{ github.api_url }}
 outputs:
   markdown-file:
     description: "The markdown that will be posted to the job summary, so that the markdown can saved and used other places (e.g.: README.md)"
@@ -50,7 +53,7 @@ runs:
       id: lead-time
       shell: pwsh
       run: |
-         $result = ${{ github.action_path }}/src/leadtimeforchanges.ps1 -ownerRepo "${{ inputs.owner-repo }}" -workflows "${{ inputs.workflows }}" -branch "${{ inputs.default-branch }}" -numberOfDays ${{ inputs.number-of-days }} -commitCountingMethod ${{ inputs.commit-counting-method }} -patToken "${{ inputs.pat-token }}" -actionsToken "${{ inputs.actions-token }}" -appId "${{ inputs.app-id }}" -appInstallationId "${{ inputs.app-install-id }}" -appPrivateKey "${{ inputs.app-private-key }}"             
+         $result = ${{ github.action_path }}/src/leadtimeforchanges.ps1 -ownerRepo "${{ inputs.owner-repo }}" -workflows "${{ inputs.workflows }}" -branch "${{ inputs.default-branch }}" -numberOfDays ${{ inputs.number-of-days }} -commitCountingMethod ${{ inputs.commit-counting-method }} -patToken "${{ inputs.pat-token }}" -actionsToken "${{ inputs.actions-token }}" -appId "${{ inputs.app-id }}" -appInstallationId "${{ inputs.app-install-id }}" -appPrivateKey "${{ inputs.app-private-key }}" -apiUrl "${{ inputs.api-url }}"
          $filePath="dora-lead-time-markdown.md"
          Set-Content -Path $filePath -Value $result
          "markdown-file=$filePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
The api url is set by the particular installation of GHES and available via the `${{ github.api_url }}` context variable.  I made the api url an input in case GHES support teams would like to explicitly test a non-prod or sandbox environment.

See https://docs.github.com/en/enterprise-server@3.13/actions/writing-workflows/choosing-what-your-workflow-does/contexts#github-context