### PR TITLE
Get all PRs in in the last $numberOfDays instead of only the first 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@ A GitHub Action to roughly calculate DORA lead time for changes This is not mean
 [![Current Release](https://img.shields.io/github/release/DeveloperMetrics/lead-time-for-changes/all.svg)](https://github.com/DeveloperMetrics/lead-time-for-changes/releases)
 
 ## Current Calculation
-- Get the last 100 closed Pull Requests
+- Get the pull requests merged in the last 30 days
 - For each Pull Request, if it was merged in the last 30 days, calculate the time the PR was open, taking the merge time and either the first or last commit time (specified as a parameter), aggregating for an overall PR duration average.
 - For each workflow, if it started in the last 30 days and was run on the target branch, calculate the workflow run time, aggregating for an overall workflow duration average
 - Add the Pull Request and workflow durations to output the lead time for changes result.
 - Then translate this result to friendly n days/weeks/months.
-
-## Current Limitations
-- Only looks at the last 100 closed Pull Requests and 100 completed workflows. If number of Pull Requests and/or deployments to the target branch is low, this will skew the result.
 
 ## Open questions
 

--- a/src/leadtimeforchanges.ps1
+++ b/src/leadtimeforchanges.ps1
@@ -51,7 +51,7 @@ function Main ([string] $ownerRepo,
     $page = 1
     $prsResponse = New-Object System.Collections.ArrayList
     while(1) {
-        $date = (Get-Date).AddDays(-$numberOfDays).ToString("yyy-MM-dd")
+        $date = (Get-Date).AddDays(-$numberOfDays).ToString("yyyy-MM-dd")
         $uri = "$apiUrl/search/issues?q=repo:$owner/$repo+is:pr+is:merged+base:$branch+merged:>$date&per_page=100&page=$page";
         if (!$authHeader)
         {

--- a/src/leadtimeforchanges.ps1
+++ b/src/leadtimeforchanges.ps1
@@ -70,8 +70,13 @@ function Main ([string] $ownerRepo,
         Foreach ($issue in $batch.items){
             $prsResponse.Add($issue) | Out-Null
         }
-        if($prsResponse.Count -ge $batch.total_count)
-        {
+        if ($batch.items.Count -eq 0) {
+            break
+        }
+        if (($page * 100) -ge $batch.total_count) {
+            break
+        }
+        if ($prsResponse.Count -ge $batch.total_count) {
             break
         }
         $page += 1


### PR DESCRIPTION
To get all prs that match the conditions (merged in the last $numberOfDays days), we can use the search api and get all the issues that matches (prs are issues).
This way we can limit the returned prs to only the ones we want, right from the start.
The API supports pagination, in case the number of prs are higher than the number returned each time